### PR TITLE
Update socket intialization logic to handle ws:// and wss:// application transport

### DIFF
--- a/Bin/Client.php
+++ b/Bin/Client.php
@@ -37,7 +37,6 @@
 namespace Hoa\Websocket\Bin;
 
 use Hoa\Console;
-use Hoa\Socket;
 use Hoa\Websocket;
 
 /**
@@ -93,7 +92,7 @@ class Client extends Console\Dispatcher\Kit
 
         $readline = new Console\Readline();
         $client   = new Websocket\Client(
-            new Socket\Client('tcp://' . $server)
+            new Websocket\Connection('tcp://' . $server)
         );
         $client->setHost('localhost');
         $client->connect();

--- a/Client.php
+++ b/Client.php
@@ -38,7 +38,7 @@ namespace Hoa\Websocket;
 
 use Hoa\Core;
 use Hoa\Http;
-use Hoa\Socket;
+use Hoa\Socket as BaseSocket;
 
 /**
  * Class \Hoa\Websocket\Client.
@@ -83,7 +83,7 @@ class Client extends Connection\Handler
      * @throws  \Hoa\Socket\Exception
      */
     public function __construct(
-        Socket\Client $client,
+        BaseSocket\Client $client,
         $endPoint               = '/',
         Http\Response $response = null
     ) {

--- a/Client.php
+++ b/Client.php
@@ -152,6 +152,11 @@ class Client extends Connection
 
         $connection = $this->getConnection();
         $connection->connect();
+
+        if( $connection->getSocket()->isSecured() ) {
+            $connection->enableEncryption(true, $connection::ENCRYPTION_TLS);
+        }
+
         $connection->setStreamBlocking(true);
 
         $key =

--- a/Client.php
+++ b/Client.php
@@ -48,7 +48,7 @@ use Hoa\Socket;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Client extends Connection
+class Client extends Connection\Handler
 {
     /**
      * Endpoint.

--- a/Client.php
+++ b/Client.php
@@ -153,7 +153,8 @@ class Client extends Connection\Handler
         $connection = $this->getConnection();
         $connection->connect();
 
-        if( $connection->getSocket()->isSecured() ) {
+        if( $connection->getSocket() instanceof Hoa\Websocket\Socket &&
+            $connection->getSocket()->isSecured() ) {
             $connection->enableEncryption(true, $connection::ENCRYPTION_TLS);
         }
 

--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Websocket\Connection;
+
+use Hoa\Websocket\Socket;
+use Hoa\Socket\Client;
+use Hoa\Core;
+
+/**
+ * Class \Hoa\Socket\Connection.
+ *
+ * Abstract connection, useful for client and server.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Connection extends Client
+{
+    /**
+     * Set socket.
+     *
+     * @param   string  $socket    Socket URI.
+     * @return  \Hoa\Socket
+     */
+    protected function setSocket($socket)
+    {
+        $old           = $this->_socket;
+        $this->_socket = new Socket($socket);
+
+        return $old;
+    }
+}
+
+/**
+ * Flex entity.
+ */
+Core\Consistency::flexEntity('Hoa\Websocket\Connection\Connection');

--- a/Connection/Handler.php
+++ b/Connection/Handler.php
@@ -196,7 +196,7 @@ abstract class Handler
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
-    public function __construct(Connection $connection)
+    public function __construct(Socket\Connection $connection)
     {
         parent::__construct($connection);
         $this->getConnection()->setNodeName('\Hoa\Websocket\Node');

--- a/Connection/Handler.php
+++ b/Connection/Handler.php
@@ -34,7 +34,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Hoa\Websocket;
+namespace Hoa\Websocket\Connection;
 
 use Hoa\Core;
 use Hoa\Socket;
@@ -47,7 +47,7 @@ use Hoa\Socket;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-abstract class Connection
+abstract class Handler
     extends    Socket\Connection\Handler
     implements Core\Event\Listenable
 {
@@ -196,7 +196,7 @@ abstract class Connection
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
-    public function __construct(Socket\Connection $connection)
+    public function __construct(Connection $connection)
     {
         parent::__construct($connection);
         $this->getConnection()->setNodeName('\Hoa\Websocket\Node');

--- a/Exception/CloseError.php
+++ b/Exception/CloseError.php
@@ -49,7 +49,7 @@ class CloseError extends Exception
     /**
      * Error code.
      *
-     * One of the \Hoa\Websocket\Connection::CLOSE_* constants.
+     * One of the \Hoa\Websocket\Connection\Handler::CLOSE_* constants.
      *
      * @var int
      */

--- a/Node.php
+++ b/Node.php
@@ -36,7 +36,7 @@
 
 namespace Hoa\Websocket;
 
-use Hoa\Socket;
+use Hoa\Socket as BaseSocket;
 
 /**
  * Class \Hoa\Websocket\Node.
@@ -46,7 +46,7 @@ use Hoa\Socket;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Node extends Socket\Node
+class Node extends BaseSocket\Node
 {
     /**
      * Protocol implementation.

--- a/Protocol/Generic.php
+++ b/Protocol/Generic.php
@@ -101,7 +101,7 @@ abstract class Generic
      */
     abstract public function writeFrame(
         $message,
-        $opcode = Websocket\Connection::OPCODE_TEXT_FRAME,
+        $opcode = Websocket\Connection\Handler::OPCODE_TEXT_FRAME,
         $end    = true,
         $mask   = false
     );
@@ -117,7 +117,7 @@ abstract class Generic
      */
     abstract public function send(
         $message,
-        $opcode = Websocket\Connection::OPCODE_TEXT_FRAME,
+        $opcode = Websocket\Connection\Handler::OPCODE_TEXT_FRAME,
         $end    = true,
         $mask   = false
     );
@@ -126,14 +126,14 @@ abstract class Generic
      * Close a specific node/connection.
      *
      * @param   int     $code      Code (please, see
-     *                             \Hoa\Websocket\Connection::CLOSE_*
+     *                             \Hoa\Websocket\Connection\Handler::CLOSE_*
      *                             constants).
      * @param   string  $reason    Reason.
      * @param   bool    $mask      Whether the message will be masked or not.
      * @return  void
      */
     abstract public function close(
-        $code   = Websocket\Connection::CLOSE_NORMAL,
+        $code   = Websocket\Connection\Handler::CLOSE_NORMAL,
         $reason = null,
         $mask   = false
     );

--- a/Protocol/Hybi00.php
+++ b/Protocol/Hybi00.php
@@ -110,7 +110,7 @@ class Hybi00 extends Generic
                 'rsv1'    => 0x0,
                 'rsv2'    => 0x0,
                 'rsv3'    => 0x0,
-                'opcode'  => Websocket\Connection::OPCODE_CONNECTION_CLOSE,
+                'opcode'  => Websocket\Connection\Handler::OPCODE_CONNECTION_CLOSE,
                 'mask'    => 0x0,
                 'length'  => 0,
                 'message' => null
@@ -122,7 +122,7 @@ class Hybi00 extends Generic
             'rsv1'    => 0x0,
             'rsv2'    => 0x0,
             'rsv3'    => 0x0,
-            'opcode'  => Websocket\Connection::OPCODE_TEXT_FRAME,
+            'opcode'  => Websocket\Connection\Handler::OPCODE_TEXT_FRAME,
             'mask'    => 0x0,
             'length'  => $length,
             'message' => substr($buffer, 1, $length)
@@ -169,14 +169,14 @@ class Hybi00 extends Generic
      * Close a specific node/connection.
      *
      * @param   int     $code      Code (please, see
-     *                             \Hoa\Websocket\Connection::CLOSE_*
+     *                             \Hoa\Websocket\Connection\Handler::CLOSE_*
      *                             constants).
      * @param   string  $reason    Reason.
      * @param   bool    $mask      Whether the message will be masked or not.
      * @return  void
      */
     public function close(
-        $code   = Websocket\Connection::CLOSE_NORMAL,
+        $code   = Websocket\Connection\Handler::CLOSE_NORMAL,
         $reason = null,
         $mask   = false
     ) {

--- a/Protocol/Rfc6455.php
+++ b/Protocol/Rfc6455.php
@@ -118,7 +118,7 @@ class Rfc6455 extends Generic
         $read = $this->_connection->read(1);
 
         if (empty($read)) {
-            $out['opcode'] = Websocket\Connection::OPCODE_CONNECTION_CLOSE;
+            $out['opcode'] = Websocket\Connection\Handler::OPCODE_CONNECTION_CLOSE;
 
             return $out;
         }
@@ -142,7 +142,7 @@ class Rfc6455 extends Generic
                 [$out['rsv1'], $out['rsv2'], $out['rsv3']]
             );
             $exception->setErrorCode(
-                Websocket\Connection::CLOSE_PROTOCOL_ERROR
+                Websocket\Connection\Handler::CLOSE_PROTOCOL_ERROR
             );
 
             throw $exception;
@@ -165,7 +165,7 @@ class Rfc6455 extends Generic
                     3
                 );
                 $exception->setErrorCode(
-                    Websocket\Connection::CLOSE_MESSAGE_TOO_BIG
+                    Websocket\Connection\Handler::CLOSE_MESSAGE_TOO_BIG
                 );
 
                 throw $exception;
@@ -187,7 +187,7 @@ class Rfc6455 extends Generic
                 4
             );
             $exception->setErrorCode(
-                Websocket\Connection::CLOSE_PROTOCOL_ERROR
+                Websocket\Connection\Handler::CLOSE_PROTOCOL_ERROR
             );
 
             throw $exception;
@@ -225,7 +225,7 @@ class Rfc6455 extends Generic
      */
     public function writeFrame(
         $message,
-        $opcode = Websocket\Connection::OPCODE_TEXT_FRAME,
+        $opcode = Websocket\Connection\Handler::OPCODE_TEXT_FRAME,
         $end    = true,
         $mask   = false
     ) {
@@ -293,12 +293,12 @@ class Rfc6455 extends Generic
      */
     public function send(
         $message,
-        $opcode = Websocket\Connection::OPCODE_TEXT_FRAME,
+        $opcode = Websocket\Connection\Handler::OPCODE_TEXT_FRAME,
         $end    = true,
         $mask   = false
     ) {
-        if ((Websocket\Connection::OPCODE_TEXT_FRAME         === $opcode ||
-             Websocket\Connection::OPCODE_CONTINUATION_FRAME === $opcode) &&
+        if ((Websocket\Connection\Handler::OPCODE_TEXT_FRAME         === $opcode ||
+             Websocket\Connection\Handler::OPCODE_CONTINUATION_FRAME === $opcode) &&
             false === (bool) preg_match('//u', $message)) {
             throw new Websocket\Exception\InvalidMessage(
                 'Message “%s” is not in UTF-8, cannot send it.',
@@ -318,20 +318,20 @@ class Rfc6455 extends Generic
      * Close a connection.
      *
      * @param   int     $code      Code (please, see
-     *                             \Hoa\Websocket\Connection::CLOSE_*
+     *                             \Hoa\Websocket\Connection\Handler::CLOSE_*
      *                             constants).
      * @param   string  $reason    Reason.
      * @param   bool    $mask      Whether the message will be masked or not.
      * @return  void
      */
     public function close(
-        $code   = Websocket\Connection::CLOSE_NORMAL,
+        $code   = Websocket\Connection\Handler::CLOSE_NORMAL,
         $reason = null,
         $mask   = false
     ) {
         $this->writeFrame(
             pack('n', $code) . $reason,
-            Websocket\Connection::OPCODE_CONNECTION_CLOSE,
+            Websocket\Connection\Handler::OPCODE_CONNECTION_CLOSE,
             true,
             $mask
         );

--- a/Server.php
+++ b/Server.php
@@ -47,7 +47,7 @@ use Hoa\Socket;
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-class Server extends Connection
+class Server extends Connection\Handler
 {
     /**
      * Request (mainly parser).

--- a/Socket.php
+++ b/Socket.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Websocket;
+
+use Hoa\Core;
+use Hoa\Socket as BaseSocket;
+
+/**
+ * Class \Hoa\Websocket\Socket.
+ *
+ * Socket analyzer.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Socket extends BaseSocket
+{
+    /**
+     * Address.
+     *
+     * @var string
+     */
+    protected $_secured     = false;
+
+    /**
+     * Constructor.
+     *
+     * @param   string  $uri    URI.
+     * @return  void
+     */
+    public function __construct($uri)
+    {
+        if( false === $parts = parse_url($uri) ) {
+            throw new Exception(
+                'URI "%s" can\'t be parsed.',
+                3,
+                $uri
+            );
+        }
+
+        switch( $parts['scheme'] ) {
+            case 'ws':
+                $uri = 'tcp://'.$parts['host'].(isset($parts['port'])?':'.$parts['port']:':80');
+                break;
+            case 'wss':
+                $uri = 'tcp://'.$parts['host'].(isset($parts['port'])?':'.$parts['port']:':443');
+                $this->_secured = true;
+                break;
+        }
+
+        parent::__construct($uri);
+    }
+
+    /**
+     * Set secured mode on the current socket.
+     *
+     * @param   boolean  $secured    Node name.
+     * @return  boolean
+     */
+    public function setSecured($secured)
+    {
+        $old            = $this->_secured;
+        $this->_secured = $secured;
+
+        return $old;
+    }
+
+
+    /**
+     * Check if the current socket is secured or not
+     *
+     * @return boolean
+     */
+    public function isSecured()
+    {
+        return $this->_secured;
+    }
+}


### PR DESCRIPTION
I've refactored some objects in the Hoa\Websocket lib and I've added :
- new `Socket` extension to deal with application transport ;
- new `Connection` extension to deal with the new `Socket` implementation ;
- new `Handler` name to be more precise regarding to `Hoa\Socket` implementation

The following code allow me to connect to a websocket server :

``` php
<?php
use Hoa\Websocket;

$url = "wss://examplehost.com";
$endpoint = "/";

$connection = new Websocket\Connection($url);
$client = new Websocket\Client( $connection, $endoint );
$client->setHost('hoa-project.net');

$client->connect();
var_dump($connection->isConnected()); //bool(true)
$client->close();
```

This PR is related to :
- hoaproject/Websocket#41 => Implement the `isSecured` checked to enable encryption
- hoaproject/Websocket#44 => Refactor part of the logic to be more accurate with `Hoa\Socket`
- hoaproject/Socket#26 => Implement the application transport handling at Websocket level to let the `Hoa\Socket` layer as generic as possible.
