### PR TITLE
Feature/socket wrapper

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -163,8 +163,7 @@ class Client extends Connection
         $connection = $this->getConnection();
         $connection->connect();
 
-        if( $connection->getSocket() instanceof Socket &&
-            $connection->getSocket()->isSecure()) {
+        if ($connection->getSocket()->isSecured()) {
             $connection->enableEncryption(true, $connection::ENCRYPTION_TLS);
         }
 

--- a/Client.php
+++ b/Client.php
@@ -85,10 +85,19 @@ class Client extends Connection
      */
     public function __construct(
         HoaSocket\Client $client,
-        $endPoint               = '/',
+        $endPoint               = null,
         Http\Response $response = null
     ) {
         parent::__construct($client);
+
+        if (null === $endPoint) {
+            $endPoint = '/';
+
+            if ($client->getSocket() instanceof Socket) {
+                $endPoint = $client->getSocket()->getEndPoint();
+            }
+
+        }
         $this->setEndPoint($endPoint);
 
         if (null === $response) {

--- a/Client.php
+++ b/Client.php
@@ -96,8 +96,8 @@ class Client extends Connection
             if ($client->getSocket() instanceof Socket) {
                 $endPoint = $client->getSocket()->getEndPoint();
             }
-
         }
+
         $this->setEndPoint($endPoint);
 
         if (null === $response) {

--- a/Client.php
+++ b/Client.php
@@ -39,7 +39,7 @@ namespace Hoa\Websocket;
 use Hoa\Consistency;
 use Hoa\Event;
 use Hoa\Http;
-use Hoa\Socket;
+use Hoa\Socket as HoaSocket;
 
 /**
  * Class \Hoa\Websocket\Client.
@@ -84,7 +84,7 @@ class Client extends Connection
      * @throws  \Hoa\Socket\Exception
      */
     public function __construct(
-        Socket\Client $client,
+        HoaSocket\Client $client,
         $endPoint               = '/',
         Http\Response $response = null
     ) {
@@ -153,6 +153,12 @@ class Client extends Connection
 
         $connection = $this->getConnection();
         $connection->connect();
+
+        if( $connection->getSocket() instanceof Socket &&
+            $connection->getSocket()->isSecure()) {
+            $connection->enableEncryption(true, $connection::ENCRYPTION_TLS);
+        }
+
         $connection->setStreamBlocking(true);
 
         $key =

--- a/Connection.php
+++ b/Connection.php
@@ -540,3 +540,9 @@ abstract class Connection
         return $connection->disconnect();
     }
 }
+
+/**
+ * Register socket wrappers
+ */
+HoaSocket\Transport::registerWrapper('ws', ['Hoa\Websocket\Socket', 'createFromUri']);
+HoaSocket\Transport::registerWrapper('wss', ['Hoa\Websocket\Socket', 'createFromUri']);

--- a/Connection.php
+++ b/Connection.php
@@ -540,9 +540,3 @@ abstract class Connection
         return $connection->disconnect();
     }
 }
-
-/**
- * Register socket wrappers
- */
-HoaSocket\Transport::registerWrapper('ws', ['Hoa\Websocket\Socket', 'createFromUri']);
-HoaSocket\Transport::registerWrapper('wss', ['Hoa\Websocket\Socket', 'createFromUri']);

--- a/Connection.php
+++ b/Connection.php
@@ -38,7 +38,7 @@ namespace Hoa\Websocket;
 
 use Hoa\Event;
 use Hoa\Exception as HoaException;
-use Hoa\Socket;
+use Hoa\Socket as HoaSocket;
 
 /**
  * Class \Hoa\Websocket\Connection.
@@ -49,7 +49,7 @@ use Hoa\Socket;
  * @license    New BSD License
  */
 abstract class Connection
-    extends    Socket\Connection\Handler
+    extends    HoaSocket\Connection\Handler
     implements Event\Listenable
 {
     use Event\Listens;
@@ -191,7 +191,7 @@ abstract class Connection
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
-    public function __construct(Socket\Connection $connection)
+    public function __construct(HoaSocket\Connection $connection)
     {
         parent::__construct($connection);
         $this->getConnection()->setNodeName('\Hoa\Websocket\Node');
@@ -218,7 +218,7 @@ abstract class Connection
      * @param   \Hoa\Socket\Node  $node    Node.
      * @return  void
      */
-    protected function _run(Socket\Node $node)
+    protected function _run(HoaSocket\Node $node)
     {
         try {
             if (FAILED === $node->getHandshake()) {
@@ -482,7 +482,7 @@ abstract class Connection
      * @param   \Hoa\Socket\Node  $node       Node.
      * @return  \Closure
      */
-    protected function _send($message, Socket\Node $node)
+    protected function _send($message, HoaSocket\Node $node)
     {
         $mustMask = $this instanceof Client;
 
@@ -506,7 +506,7 @@ abstract class Connection
      */
     public function send(
         $message,
-        Socket\Node $node = null,
+        HoaSocket\Node $node = null,
         $opcode = self::OPCODE_TEXT_FRAME,
         $end = true
     ) {

--- a/Node.php
+++ b/Node.php
@@ -36,7 +36,7 @@
 
 namespace Hoa\Websocket;
 
-use Hoa\Socket;
+use Hoa\Socket as HoaSocket;
 
 /**
  * Class \Hoa\Websocket\Node.
@@ -46,7 +46,7 @@ use Hoa\Socket;
  * @copyright  Copyright © 2007-2016 Hoa community
  * @license    New BSD License
  */
-class Node extends Socket\Node
+class Node extends HoaSocket\Node
 {
     /**
      * Protocol implementation.

--- a/Server.php
+++ b/Server.php
@@ -37,7 +37,7 @@
 namespace Hoa\Websocket;
 
 use Hoa\Http;
-use Hoa\Socket;
+use Hoa\Socket as HoaSocket;
 
 /**
  * Class \Hoa\Websocket\Server.
@@ -67,7 +67,7 @@ class Server extends Connection
      * @throws  \Hoa\Socket\Exception
      */
     public function __construct(
-        Socket\Server $server,
+        HoaSocket\Server $server,
         Http\Request  $request = null
     ) {
         parent::__construct($server);

--- a/Server.php
+++ b/Server.php
@@ -68,7 +68,7 @@ class Server extends Connection
      */
     public function __construct(
         HoaSocket\Server $server,
-        Http\Request  $request = null
+        Http\Request     $request = null
     ) {
         parent::__construct($server);
 

--- a/Socket.php
+++ b/Socket.php
@@ -83,16 +83,17 @@ class Socket extends HoaSocket
     }
 
     /**
-     * Factory to create a valid instance from URI
-     * @param string $socketUri
+     * Factory to create a valid instance from the given URI
+     *
+     * @param string $socketUri URI of the socket to connect to.
      * @return void
      */
-    public static function createFromUri($socketUri)
+    public static function transportFactory($socketUri)
     {
         $parsed = parse_url($socketUri);
-        if( false === $parsed ) {
+        if (false === $parsed) {
             throw new Exception(
-                'URI %s is not recognized.',
+                'URI "%s" can\'t be parsed with `parse_url`.',
                 0,
                 $socketUri
             );

--- a/Socket.php
+++ b/Socket.php
@@ -36,7 +36,6 @@
 
 namespace Hoa\Websocket;
 
-use Hoa\Core;
 use Hoa\Socket as HoaSocket;
 
 /**
@@ -50,13 +49,6 @@ use Hoa\Socket as HoaSocket;
 class Socket extends HoaSocket
 {
     /**
-     * Secured ?
-     *
-     * @var boolean
-     */
-    protected $_secure   = false;
-
-    /**
      * Endpoint.
      *
      * @var string
@@ -67,27 +59,17 @@ class Socket extends HoaSocket
      * Constructor
      *
      * @param string  $uri      Socket URI
-     * @param boolean $secure   Secure mode
+     * @param boolean $secured  Secure mode
      * @param string  $endPoint Websocket endpoint
      */
-    public function __construct($uri, $secure = false, $endPoint = '/')
+    public function __construct($uri, $secured = false, $endPoint = '/')
     {
         parent::__construct($uri);
 
-        $this->_secure = $secure;
+        $this->_secured  = $secured;
         $this->_endPoint = $endPoint;
 
         return;
-    }
-
-    /**
-     * Check if the socket is secured
-     *
-     * @return boolean
-     */
-    public function isSecure()
-    {
-        return $this->_secure;
     }
 
     /**

--- a/Socket.php
+++ b/Socket.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Websocket;
+
+use Hoa\Core;
+use Hoa\Socket as HoaSocket;
+
+/**
+ * Class \Hoa\Websocket\Socket.
+ *
+ * Websocket specific socket extension.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Socket extends HoaSocket
+{
+    /**
+     * Secured ?
+     *
+     * @var boolean
+     */
+    protected $_secure   = false;
+
+    /**
+     * Endpoint.
+     *
+     * @var string
+     */
+    protected $_endPoint = '/';
+
+    /**
+     * Constructor
+     *
+     * @param string  $uri      Socket URI
+     * @param boolean $secure   Secure mode
+     * @param string  $endPoint Websocket endpoint
+     */
+    public function __construct($uri, $secure = false, $endPoint = '/')
+    {
+        parent::__construct($uri);
+
+        $this->_secure = $secure;
+        $this->_endPoint = $endPoint;
+
+        return;
+    }
+
+    /**
+     * Check if the socket is secured
+     *
+     * @return boolean
+     */
+    public function isSecure()
+    {
+        return $this->_secure;
+    }
+
+    /**
+     * Retrieve the websocket endpoint
+     *
+     * @return string
+     */
+    public function getEndPoint()
+    {
+        return $this->_endPoint;
+    }
+}

--- a/Socket.php
+++ b/Socket.php
@@ -133,3 +133,9 @@ class Socket extends HoaSocket
         );
     }
 }
+
+/**
+ * Register socket wrappers
+ */
+HoaSocket\Transport::register('ws',  ['Hoa\Websocket\Socket', 'transportFactory']);
+HoaSocket\Transport::register('wss', ['Hoa\Websocket\Socket', 'transportFactory']);

--- a/Socket.php
+++ b/Socket.php
@@ -99,4 +99,37 @@ class Socket extends HoaSocket
     {
         return $this->_endPoint;
     }
+
+    /**
+     * Factory to create a valid instance from URI
+     * @param string $socketUri
+     * @return void
+     */
+    public static function createFromUri($socketUri)
+    {
+        $parsed = parse_url($socketUri);
+        if( false === $parsed ) {
+            throw new Exception(
+                'URI %s is not recognized.',
+                0,
+                $socketUri
+            );
+        }
+
+        $secure = isset($parsed['scheme'])?
+            'wss' === $parsed['scheme']:
+            false;
+
+        if (isset($parsed['port'])) {
+            $port = $parsed['port'];
+        } else {
+            $port = true === $secure ? 443 : 80;
+        }
+
+        return new static(
+            'tcp://' . $parsed['host'] . ':' . $port,
+            $secure,
+            isset($parsed['path'])?$parsed['path']:'/'
+        );
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr-4": {
             "Hoa\\Websocket\\": "."
         },
-        "files": [ "Connection.php" ]
+        "files": [ "Socket.php" ]
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "autoload": {
         "psr-4": {
             "Hoa\\Websocket\\": "."
-        }
+        },
+        "files": [ "Connection.php" ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Hello !

Here the PR about the implementation of hoaproject/Socket#27 in the websocket project.

I tried to make it clean :
- Must use `WebsocketSocket` instead of just `Socket` to avoid `Socket` name reusing (due to `Hoa\Socket\Socket` flexion) ;
- Retrieve `endPoint` from the socket if it is not given to `Websocket\Client` constructor ;
- Add the factories to `Websocket\Connection`.

But I have a problem about factories loading... They are defined in the Websocket lib so if I construct a `Socket\Client` before using `Websocket\Client` the factories are not yet loaded...

Examples :

``` php
<?php
$connection = new Socket\Client('wss://0.0.0.0/a/path');
// Here the transport wrappers are not yet registered because classes are loaded
// only at first use
$client = new Websocket\Client($connection);
// They are defined here but too late, I already get a "wss transport does not exists" exception
```

``` php
<?php
// That way it works because PHP parser encounter the `Websocket\Client` token
// before the `Socket\Client`
$client = new Websocket\Client(
    new Socket\Client('wss://0.0.0.0/a/path')
);
```

For me there is 3 approachs to use here :
- Create an extension of `Socket\Client` and use it instead of the root class to enable and use the wrappers properly ;
- Change the register approach (I haven't idea here) ;
- Create a factory for the Websocket\Client which handle `Socket\Client` creation.

I think it's not really valid because sometimes the code will works, sometimes not because of instruction order...

I haven't added tests for the moment because we need to validate the approach before...
