### PR TITLE
Fix notice on PHP 5.5+

### DIFF
--- a/Node.php
+++ b/Node.php
@@ -78,6 +78,8 @@ class Node extends Socket\Node
 
     /**
      * Whether the message is complete or not.
+     *
+     * @var bool
      */
     protected $_complete          = true;
 
@@ -222,11 +224,11 @@ class Node extends Socket\Node
     /**
      * Clear the fragmentation.
      *
-     * @return  string
+     * @return  void
      */
     public function clearFragmentation()
     {
-        unset($this->_messageFragments);
+        $this->_messageFragments  = null;
         $this->_numberOfFragments = 0;
         $this->_isBinary          = false;
         $this->_complete          = true;


### PR DESCRIPTION
The behavior of creating property from non-existent property has changed in 5.5, it cause now a notice.

Test on 3v4l.org here : [unset vs assign to null](http://3v4l.org/7nSEJ) and [changed behavior](http://3v4l.org/dnj4q).
Related patch: https://bugs.php.net/bug.php?id=49348

Notice is: `PHP Notice:  Undefined property: Hoa\Websocket\Node::$_messageFragments in …hoa\websocket\Node.php on line 151
`