### PR TITLE
Update `Websocket\Server` and `Websocket\Client` constructor behaviour

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -77,17 +77,26 @@ class Client extends Connection
     /**
      * Create a Websocket client.
      *
-     * @param   \Hoa\Socket\Client  $client      Client.
-     * @param   string              $endPoint    End-point.
-     * @param   \Hoa\Http\Response  $request     Response parser.
+     * @param   string|\Hoa\Socket\Client   $client      Client.
+     * @param   string                      $endPoint    End-point.
+     * @param   \Hoa\Http\Response          $request     Response parser.
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
     public function __construct(
-        Socket\Client $client,
+        $client,
         $endPoint               = '/',
         Http\Response $response = null
     ) {
+        if (is_string($client)) {
+            $client = new Socket\Client($client);
+        } elseif (!($client instanceof Socket\Client)) {
+            throw new Exception(
+                'Client must be a valid Hoa\Socket\Client instance'
+            );
+        }
+
+
         parent::__construct($client);
         $this->setEndPoint($endPoint);
 

--- a/Documentation/En/Index.xyl
+++ b/Documentation/En/Index.xyl
@@ -99,6 +99,10 @@
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
     new Hoa\Socket\Server('tcp://127.0.0.1:8889')
 );</code></pre>
+  <p>It's also possible to build the WebSocket server directly from socket URI:</p>
+  <pre><code class="language-php">$server = new Hoa\Websocket\Server(
+    'tcp://127.0.0.1:8889'
+);</code></pre>
   <p>Now, let's see how to <strong>interact</strong> with this server.</p>
 
   <h3 id="Listeners" for="main-toc">Listeners</h3>
@@ -474,6 +478,11 @@ $client->on('message', function (Hoa\Event\Bucket $bucket) {
 
     return;
 });</code></pre>
+  <p>It's also possible to build the WebSocket client instance directly from the
+    socket URI. So we can write:</p>
+  <pre><code class="language-php">$client = new Hoa\Websocket\Client(
+    'tcp://127.0.0.1:8889'
+);</code></pre>
   <p>The client can work in loop mode, like the server, with the
   <code>run</code> method. In this case, we will write:</p>
   <pre><code class="language-php">$client->run();</code></pre>
@@ -555,7 +564,7 @@ $client->connect();
   <code>Hoa\Socket\Client::setNodeName</code> methods allow to specify what
   node class the server or the client will <strong>use</strong>:</p>
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
-    new Hoa\Socket\Server('tcp://127.0.0.1:8889')
+    'tcp://127.0.0.1:8889'
 );
 $server->getConnection()->setNodeName('ChatNode');</code></pre>
   <p>Next, in our listeners for example, we will be able to use our

--- a/Documentation/Fr/Index.xyl
+++ b/Documentation/Fr/Index.xyl
@@ -109,6 +109,11 @@
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
     new Hoa\Socket\Server('tcp://127.0.0.1:8889')
 );</code></pre>
+  <p>Il est aussi possible de construire une instance de serveur WebSocket
+    directement à partir de l'URI du socket :</p>
+  <pre><code class="language-php">$server = new Hoa\Websocket\Server(
+    'tcp://127.0.0.1:8889'
+);</code></pre>
   <p>Maintenant, voyons comment <strong>interagir</strong> avec ce serveur.</p>
 
   <h3 id="Listeners" for="main-toc">Écouteurs</h3>
@@ -493,7 +498,7 @@ $server->run();</code></pre>
   positionnés sur le client.</p>
   <p>Ainsi, pour démarrer un client, nous écrirons :</p>
   <pre><code class="language-php">$client = new Hoa\Websocket\Client(
-    new Hoa\Socket\Client('tcp://127.0.0.1:8889')
+    'tcp://127.0.0.1:8889'
 );
 $client->on('message', function (Hoa\Event\Bucket $bucket) {
     $data = $bucket->getData();
@@ -501,6 +506,11 @@ $client->on('message', function (Hoa\Event\Bucket $bucket) {
 
     return;
 });</code></pre>
+  <p>Il est aussi possible de construire un client WebSocket directement à partir
+    de l'URI du socket. Nous pouvons donc écrire :</p>
+  <pre><code class="language-php">$client = new Hoa\Websocket\Client(
+    'tcp://127.0.0.1:8889'
+);</code></pre>
   <p>Le client peut fonctionner en mode <em lang="en">loop</em>, comme le
   serveur, avec la méthode <code>run</code>. Dans ce cas, nous devrons
   écrire :</p>
@@ -587,7 +597,7 @@ $client->connect();
   <code>Hoa\Socket\Server::setNodeName</code> ou
   <code>Hoa\Socket\Client::setNodeName</code> de cette manière :</p>
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
-    new Hoa\Socket\Server('tcp://127.0.0.1:8889')
+    'tcp://127.0.0.1:8889'
 );
 $server->getConnection()->setNodeName('ChatNode');</code></pre>
   <p>Et après, dans nos écouteurs, nous pourrons utiliser notre méthode

--- a/Server.php
+++ b/Server.php
@@ -61,15 +61,23 @@ class Server extends Connection
     /**
      * Create a Websocket server.
      *
-     * @param   \Hoa\Socket\Server  $server    Server.
-     * @param   \Hoa\Http\Request   $request   Request parser.
+     * @param   string|\Hoa\Socket\Server   $server    Server.
+     * @param   \Hoa\Http\Request           $request   Request parser.
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
     public function __construct(
-        Socket\Server $server,
+        $server,
         Http\Request  $request = null
     ) {
+        if (is_string($server)) {
+            $server = new Socket\Server($server);
+        } elseif (!($server instanceof Socket\Server)) {
+            throw new Exception(
+                'Server must be a valid Hoa\Socket\Server instance'
+            );
+        }
+
         parent::__construct($server);
 
         if (null === $request) {


### PR DESCRIPTION
Previously the constructors must be called with an instance of `Socket\Client` or `Socket\Server` as the first parameter.

This PR allow the constructors to build the valid instance from a string.

Added: type check + doc update
