### PR TITLE
Call to a member function send() on null

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -502,6 +502,10 @@ abstract class Connection
         $mustMask = $this instanceof Client;
 
         return function ($opcode, $end) use (&$message, $node, $mustMask) {
+            if ( ! $node->getHandshake()) {
+                return;
+            }
+
             return
                 $node
                     ->getProtocolImplementation()


### PR DESCRIPTION
hoaproject/Websocket 2.15.08.05

I have setup a small websocket server which only dispatches message to all other connected clients. I use client code available @ http://hoa-project.net/En/Awecode/Websocket.html to connect to the server with `ab`: `ab -c 50 -n 500 http://localhost/client-push.php`.

However, it appears that as soon as I do that, the websocket server crashes with the following error:

PHP Fatal error:  Call to a member function send() on null in /site/vendor/hoa/websocket/Connection.php on line 508
PHP Stack trace:
PHP   1. {main}() /site/API/X/Server.php:0
PHP   2. NAMESPACE\Server::run() /site/API/X/Server.php:11
PHP   3. Hoa\Socket\Connection\Handler->run() /site/src/Z/Y/X/Server.php:16
PHP   4. Hoa\Websocket\Connection->_run() /site/vendor/hoa/socket/Connection/Handler.php:186
PHP   5. Hoa\Core\Event\Listener->fire() /site/vendor/hoa/websocket/Connection.php:310
PHP   6. Hoa\Core\Consistency\Xcallable->__invoke() /site/vendor/hoa/core/Event.php:524
PHP   7. call_user_func_array:{/site/vendor/hoa/core/Consistency.php:762}() /site/vendor/hoa/core/Consistency.php:762
PHP   8. NAMESPACE\Server::NAMESPACE\{closure}() /site/vendor/hoa/core/Consistency.php:762
PHP   9. Hoa\Socket\Connection\Handler->broadcast() /site/src/Z/Y/X/Server.php:14
PHP  10. call_user_func_array:{/site/vendor/hoa/socket/Connection/Handler.php:288}() /site/vendor/hoa/socket/Connection/Handler.php:288
PHP  11. Hoa\Socket\Connection\Handler->broadcastIf() /site/vendor/hoa/socket/Connection/Handler.php:288
PHP  12. call_user_func_array:{/site/vendor/hoa/socket/Connection/Handler.php:323}() /site/vendor/hoa/socket/Connection/Handler.php:323
PHP  13. Hoa\Websocket\Connection->send() /site/vendor/hoa/socket/Connection/Handler.php:323
PHP  14. Hoa\Socket\Connection\Handler->Hoa\Socket\Connection\{closure}() /site/vendor/hoa/websocket/Connection.php:534
PHP  15. call_user_func_array:{/site/vendor/hoa/socket/Connection/Handler.php:257}() /site/vendor/hoa/socket/Connection/Handler.php:257
PHP  16. Hoa\Websocket\Connection->Hoa\Websocket\{closure}() /site/vendor/hoa/socket/Connection/Handler.php:257

Note that if I run `ab` without concurrency, the server does not crash.

Thanks by the way for this awesome library :)