### PR TITLE
Documentation: Introduce `ws://` and `wss://`

### DIFF
--- a/Documentation/En/Index.xyl
+++ b/Documentation/En/Index.xyl
@@ -99,6 +99,17 @@
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
     new Hoa\Socket\Server('tcp://127.0.0.1:8889')
 );</code></pre>
+  <p>However, we can use the <code>ws://127.0.0.1:8889</code> URI directly
+  instead of <code>tcp://127.0.0.1:8889</code>. This is an advantage when we
+  use <code>wss://</code> for a secured connection because
+  <code>Hoa\Websocket</code> will know that the connection will need to be
+  secured and everything will be done for you automatically. Manipulating TLS,
+  enabling encryption for certain connections etc. will not be required.
+  Thus:</p>
+  <pre><code class="language-php">$server = new Hoa\Websocket\Server(
+    new Hoa\Socket\Server('ws://127.0.0.1:8889')
+);</code></pre>
+
   <p>Now, let's see how to <strong>interact</strong> with this server.</p>
 
   <h3 id="Listeners" for="main-toc">Listeners</h3>
@@ -466,7 +477,7 @@ $server->run();</code></pre>
   client.</p>
   <p>Thus, to start a client, we will write:</p>
   <pre><code class="language-php">$client = new Hoa\Websocket\Client(
-    new Hoa\Socket\Client('tcp://127.0.0.1:8889')
+    new Hoa\Socket\Client('ws://127.0.0.1:8889')
 );
 $client->on('message', function (Hoa\Event\Bucket $bucket) {
     $data = $bucket->getData();
@@ -555,7 +566,7 @@ $client->connect();
   <code>Hoa\Socket\Client::setNodeName</code> methods allow to specify what
   node class the server or the client will <strong>use</strong>:</p>
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
-    new Hoa\Socket\Server('tcp://127.0.0.1:8889')
+    new Hoa\Socket\Server('ws://127.0.0.1:8889')
 );
 $server->getConnection()->setNodeName('ChatNode');</code></pre>
   <p>Next, in our listeners for example, we will be able to use our

--- a/Documentation/Fr/Index.xyl
+++ b/Documentation/Fr/Index.xyl
@@ -109,6 +109,15 @@
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
     new Hoa\Socket\Server('tcp://127.0.0.1:8889')
 );</code></pre>
+  <p>Toutefois, nous pouvons utiliser l'URI <code>ws://127.0.0.1:8889</code>
+  directement à la place de <code>tcp://127.0.0.1:8889</code>. Cela a un
+  avantage lorsque nous utilisons <code>wss://</code> pour une connexion
+  sécurisée car <code>Hoa\Websocket</code> saura que la connexion devra être
+  sécurisée et le fera à votre place. Vous n'aurez pas à manipuler TLS, activer
+  le cryptage sur certaines connections etc. Ainsi :</p>
+  <pre><code class="language-php">$server = new Hoa\Websocket\Server(
+    new Hoa\Socket\Server('ws://127.0.0.1:8889')
+);</code></pre>
   <p>Maintenant, voyons comment <strong>interagir</strong> avec ce serveur.</p>
 
   <h3 id="Listeners" for="main-toc">Écouteurs</h3>
@@ -493,7 +502,7 @@ $server->run();</code></pre>
   positionnés sur le client.</p>
   <p>Ainsi, pour démarrer un client, nous écrirons :</p>
   <pre><code class="language-php">$client = new Hoa\Websocket\Client(
-    new Hoa\Socket\Client('tcp://127.0.0.1:8889')
+    new Hoa\Socket\Client('ws://127.0.0.1:8889')
 );
 $client->on('message', function (Hoa\Event\Bucket $bucket) {
     $data = $bucket->getData();
@@ -587,7 +596,7 @@ $client->connect();
   <code>Hoa\Socket\Server::setNodeName</code> ou
   <code>Hoa\Socket\Client::setNodeName</code> de cette manière :</p>
   <pre><code class="language-php">$server = new Hoa\Websocket\Server(
-    new Hoa\Socket\Server('tcp://127.0.0.1:8889')
+    new Hoa\Socket\Server('ws://127.0.0.1:8889')
 );
 $server->getConnection()->setNodeName('ChatNode');</code></pre>
   <p>Et après, dans nos écouteurs, nous pourrons utiliser notre méthode

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The class `Hoa\Websocket\Server` proposes six listeners: `open`, `message`,
 
 ```php
 $websocket = new Hoa\Websocket\Server(
-    new Hoa\Socket\Server('tcp://127.0.0.1:8889')
+    new Hoa\Socket\Server('ws://127.0.0.1:8889')
 );
 $websocket->on('open', function (Hoa\Event\Bucket $bucket) {
     echo 'new connection', "\n";


### PR DESCRIPTION
We quickly explain how using `ws://` and especially `wss://` is smart and offers nice features. We didn't go through all the details. We use `ws://` and `wss://` everywhere now.