### PR TITLE
Server: Fix throws exceptions while broadcasting messages.

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -287,12 +287,21 @@ abstract class Connection
                             break;
                         }
 
-                        $this->getListener()->fire(
-                            'message',
-                            new Event\Bucket([
-                                'message' => $frame['message']
-                            ])
-                        );
+                        try {
+                            $this->getListener()->fire(
+                                'message',
+                                new Event\Bucket([
+                                    'message' => $frame['message']
+                                ])
+                            );
+                        } catch (HoaException\Group $e) {
+                            $this->getListener()->fire(
+                                'error',
+                                new Event\Bucket([
+                                    'exception' => $e
+                                ])
+                            );
+                        }
 
                         break;
                     } else {


### PR DESCRIPTION
While broadcasting a message to some nodes an error can occur because the node connection is closed but isn't yet removed from the *to send* list.
Here we will catch these exceptions to allow the server to continue working.

Fix https://github.com/hoaproject/Socket/pull/32 (`Websocket` side)
Must be merged after https://github.com/hoaproject/Socket/pull/36