### PR TITLE
Fire close event before closing and on error

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -436,7 +436,7 @@ abstract class Connection
                         }
                     }
 
-                    $this->close(self::CLOSE_NORMAL);
+                    
                     $this->getListener()->fire(
                         'close',
                         new Event\Bucket([
@@ -444,10 +444,17 @@ abstract class Connection
                             'reason' => $reason
                         ])
                     );
-
+                    $this->close(self::CLOSE_NORMAL);
                     break;
 
                 default:
+                    $this->getListener()->fire(
+                        'close',
+                        new Event\Bucket([
+                            'code'   =>self::CLOSE_PROTOCOL_ERROR,
+                            'reason' => null
+                        ])
+                    );
                     $this->close(self::CLOSE_PROTOCOL_ERROR);
             }
         } catch (HoaException\Idle $e) {


### PR DESCRIPTION
Firing the close event before closing allows for the user to grab the connection's unique ID. This is useful if the user is keeping track of connection based states across the lifecycle of a connection (e.g. session data).

Fire the event on a protocol error as well before closing.
