### PR TITLE
Connection: Handle incomplete disconnection

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -463,14 +463,20 @@ abstract class Connection
                         }
                     }
 
-                    $this->close(self::CLOSE_NORMAL);
-                    $this->getListener()->fire(
-                        'close',
-                        new Event\Bucket([
-                            'code'   => $code,
-                            'reason' => $reason
-                        ])
-                    );
+                    try {
+                        $this->close(self::CLOSE_NORMAL);
+                    } catch (HoaException\Idle $e) {
+                        // Cannot properly close the connection because the
+                        // client might already be disconnected.
+                    } finally {
+                        $this->getListener()->fire(
+                            'close',
+                            new Event\Bucket([
+                                'code'   => $code,
+                                'reason' => $reason
+                            ])
+                        );
+                    }
 
                     break;
 

--- a/Connection.php
+++ b/Connection.php
@@ -573,10 +573,14 @@ abstract class Connection
         $connection = $this->getConnection();
         $protocol   = $connection->getCurrentNode()->getProtocolImplementation();
 
-        if (null !== $protocol) {
-            $protocol->close($code, $reason);
+        try {
+            if (null !== $protocol) {
+                $protocol->close($code, $reason);
+            }
+        } finally {
+            $out = $connection->disconnect();
         }
 
-        return $connection->disconnect();
+        return $out;
     }
 }


### PR DESCRIPTION
Address #58.

First patch: _Connection: Ensure disconnection on closing_

> If the node is not able to close properly, then the socket disconnection
> was not happening nicely. This patch catches errors from a node closing
> and ensure the socket disconnection all the time.

Second patch:  _Connection: If a normal close fails, no error_

> When a normal close is attempted and it fails because of several reasons
> (it is likely to be because the client might already be disconnected and
> then it is not possible to send messages to it), then this situation is
> not considered as an error.
> 
> Indeed, the client has sent a normal close but it does not listen for
> the confirmation from the server. This is a protocol error but happening
> on closing.
> 
> So instead of getting an exception when closing, catching this exception
> later and then firing an `error` event, this makes more sense to catch
> the exception, do nothing with it, and fire the expected `close` event.

Hope it will solve the issue in #58.
