### PR TITLE
Add `close-before` event.

### DIFF
--- a/Test/Unit/Connection.php
+++ b/Test/Unit/Connection.php
@@ -121,6 +121,8 @@ class Connection extends Test\Unit\Suite
                     ->isTrue()
                 ->boolean($listener->listenerExists('ping'))
                     ->isTrue()
+                ->boolean($listener->listenerExists('close-before'))
+                    ->isTrue()
                 ->boolean($listener->listenerExists('close'))
                     ->isTrue()
                 ->boolean($listener->listenerExists('error'))


### PR DESCRIPTION
Fix #62 

I don't really like where I placed the `fire('close-before',…` call.
Adding a behavior inside a *shortcut function* seem a bad idea but otherwise we must add this call before each (14) `close` call.