### PR TITLE
PHP 7 Upgrade: Return type error in the `Bin/Client.php` class.

### DIFF
--- a/Bin/Client.php
+++ b/Bin/Client.php
@@ -76,7 +76,9 @@ class Client extends Console\Dispatcher\Kit
 
                 case 'h':
                 case '?':
-                    return $this->usage();
+                    $this->usage();
+
+                    return 0;
 
                 case '__ambiguous':
                     $this->resolveOptionAmbiguity($v);


### PR DESCRIPTION
Hello,

In the Bin/Client.php class, the return type for the `main` method is `:int`. But at line 79, there is a call to `$this->usage()` which return `void`.

Since the value returned by that method is not compatible with the `main` signature, we get an error like :

```
Uncaught TypeError: Return value of Hoa\Websocket\Bin\Client::main() must be of the type integer, null returned
```

https://github.com/hoaproject/Websocket/blob/f5cf84e5f51490f2aa88eb375bfabc1b2fcb3678/Bin/Client.php#L79

This is related to RFC: hoaproject/Central#75.